### PR TITLE
option to copy submitters is no longer optional 

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -92,17 +92,6 @@ const ContactForm = ({isDisplayed, handleClose}: IContactForm) => {
             </div>
             <div className='row justify-content-center'>
               <div className='col-sm-8'>
-                <div className='form-check bumpUpward'>
-                  <input 
-                    className='form-check-input' 
-                    id='copy-submitter'
-                    name='copy-submitter'
-                    type='checkbox' 
-                    />
-                  <label className='form-check-label' htmlFor='copy-submitter'>
-                    Send me a copy
-                  </label>
-                </div>
                 <input 
                   className='btn btn-send contactSubmitButton'
                   type='submit' 


### PR DESCRIPTION
Zapier has steep subscription costs for "multi-step Zaps". I was using this to check the contact form field for "send me a copy" and to optionally send the user a confirmation email. Now, the option has been removed and all users will recieve confirmation emails.